### PR TITLE
use regex pattern when matching files

### DIFF
--- a/src/main/java/io/cdap/plugin/batch/source/FTPBatchSource.java
+++ b/src/main/java/io/cdap/plugin/batch/source/FTPBatchSource.java
@@ -211,7 +211,7 @@ public class FTPBatchSource extends AbstractFileSource {
     @Nullable
     @Override
     public Pattern getFilePattern() {
-      return null;
+      return Strings.isNullOrEmpty(fileRegex) ? null : Pattern.compile(fileRegex);
     }
 
     @Override


### PR DESCRIPTION
Hi :)  This change allows the `AbstractFileSource` to access the regex passed through the plugin options by passing it into the `FileSourceProperties`.  The code of the change itself is modeled after https://jar-download.com/artifacts/io.cdap.plugin/format-common/2.2.0/source-code/io/cdap/plugin/format/plugin/AbstractFileSourceConfig.java