### PR TITLE
[Dependency bump] Bump cdap and hadoop versions to resolve vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,11 +34,11 @@
 
   <properties>
     <!-- properties for script build step that creates the config files for the artifacts -->
-    <data.pipeline.parent>system:cdap-data-pipeline[6.8.0-SNAPSHOT,7.0.0-SNAPSHOT)</data.pipeline.parent>
-    <data.stream.parent>system:cdap-data-streams[6.8.0-SNAPSHOT,7.0.0-SNAPSHOT)</data.stream.parent>
+    <data.pipeline.parent>system:cdap-data-pipeline[6.8.0,7.0.0-SNAPSHOT)</data.pipeline.parent>
+    <data.stream.parent>system:cdap-data-streams[6.8.0,7.0.0-SNAPSHOT)</data.stream.parent>
     <cdap.version>6.8.0</cdap.version>
     <hydrator.version>2.10.0</hydrator.version>
-    <hadoop.version>2.3.0</hadoop.version>
+    <hadoop.version>2.10.2</hadoop.version>
     <mockftp.version>2.6</mockftp.version>
     <junit.version>4.11</junit.version>
     <mockito.version>2.24.0</mockito.version>
@@ -246,12 +246,6 @@
           <artifactId>cdap-unit-test</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>io.cdap.cdap</groupId>
-      <artifactId>cdap-data-pipeline2_2.11</artifactId>
-      <version>${cdap.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
Hadoop version 2.3.0 has transitive dependency on log4j 1.2.17 which has vulnerabilities. This PR is to resolve the vulnerabilities by bumping hadoop to version 2.10.2 and also update cdap version to the latest version.

Maven build and all unit tests succeeded.

