### PR TITLE
add support for formats and other missing properties

### DIFF
--- a/docs/FTP-batchsource.md
+++ b/docs/FTP-batchsource.md
@@ -17,28 +17,41 @@ Properties
 **Reference Name:** Name used to uniquely identify this source for lineage, annotating metadata, etc.
 
 **Path:** Path to file(s) to be read. The path uses filename expansion (globbing) to read files.
-Path is expected to be of the form prefix://username:password@hostname:port/path (Macro-enabled)
+Path is expected to be of the form prefix://username:password@hostname:port/path
+
+**Format:** Format of the data to read.
+The format must be one of 'blob', 'csv', 'delimited', 'json', 'text', 'tsv', or the
+name of any format plugin that you have deployed to your environment. Note that FTP does
+not support seeking in a file, so formats like avro and parquet cannot be used.
+If the format is a macro, only the formats listed above can be used.
+If the format is 'blob', every input file will be read into a separate record.
+The 'blob' format also requires a schema that contains a field named 'body' of type 'bytes'.
+If the format is 'text', the schema must contain a field named 'body' of type 'string'.
+
+**Get Schema:** Auto-detects schema from file. Supported formats are: csv, delimited, tsv, blob and text.
+
+Blob - is set by default as field named 'body' of type bytes.
+
+Text - is set by default as two fields: 'body' of type bytes and 'offset' of type 'long'.
+
+JSON - is not supported. You must manually provide the output schema.
+
+**Delimiter:** Delimiter to use when the format is 'delimited'. This will be ignored for other formats.
+
+**Use First Row as Header:** Whether to use the first line of each file as the column headers. Supported formats are 'text', 'csv', 'tsv', and 'delimited'.
+
+**Enable Quoted Values** Whether to treat content between quotes as a value. This value will only be used if the format
+is 'csv', 'tsv' or 'delimited'. For example, if this is set to true, a line that looks like `1, "a, b, c"` will output two fields.
+The first field will have `1` as its value and the second will have `a, b, c` as its value. The quote characters will be trimmed.
+The newline delimiter cannot be within quotes.
+
+It also assumes the quotes are well enclosed. The left quote will match the first following quote right before the delimiter. If there is an
+unenclosed quote, an error will occur.
 
 **Regex Path Filter:** Regex to filter out files in the path. It accepts regular expression which is applied to the complete
-path and returns the list of files that match the specified pattern. (Macro-enabled)
-
-**File System Properties:** A JSON string representing a map of properties
-needed for the distributed file system. (Macro-enabled)
+path and returns the list of files that match the specified pattern.
 
 **Allow Empty Input:** Identify if path needs to be ignored or not, for case when directory or file does not
 exists. If set to true it will treat the not present folder as 0 input and log a warning. Default is false.
 
-
-Example
--------
-This example connects to an SFTP server and reads in files found in the specified directory.
-
-    {
-        "name": "FTP",
-        "type": "batchsource",
-        "properties": {
-            "path": "sftp://username:password@hostname:21/path/to/logs",
-            "ignoreNonExistingFolders": "false",
-            "recursive": "false"
-        }
-    }
+**File System Properties:** Additional properties to use with the InputFormat when reading the data.

--- a/pom.xml
+++ b/pom.xml
@@ -267,11 +267,6 @@
     </dependency>
     <dependency>
       <groupId>io.cdap.plugin</groupId>
-      <artifactId>format-avro</artifactId>
-      <version>${hydrator.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.cdap.plugin</groupId>
       <artifactId>format-blob</artifactId>
       <version>${hydrator.version}</version>
     </dependency>
@@ -283,16 +278,6 @@
     <dependency>
       <groupId>io.cdap.plugin</groupId>
       <artifactId>format-json</artifactId>
-      <version>${hydrator.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.cdap.plugin</groupId>
-      <artifactId>format-orc</artifactId>
-      <version>${hydrator.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.cdap.plugin</groupId>
-      <artifactId>format-parquet</artifactId>
       <version>${hydrator.version}</version>
     </dependency>
     <dependency>

--- a/src/main/java/io/cdap/plugin/batch/source/ftp/FTPBatchSource.java
+++ b/src/main/java/io/cdap/plugin/batch/source/ftp/FTPBatchSource.java
@@ -59,7 +59,7 @@ import javax.annotation.Nullable;
 @Name("FTP")
 @Description("Batch source for an FTP or SFTP source. Prefix of the path ('ftp://...' or 'sftp://...') determines " +
   "the source server type, either FTP or SFTP.")
-public class FTPBatchSource extends AbstractFileSource {
+public class FTPBatchSource extends AbstractFileSource<FTPBatchSource.FTPBatchSourceConfig> {
   public static final Logger LOG = LoggerFactory.getLogger(FTPBatchSource.class);
   private static final String NAME_FILE_SYSTEM_PROPERTIES = "fileSystemProperties";
   private static final String FS_SFTP_IMPL = "fs.sftp.impl";
@@ -70,10 +70,6 @@ public class FTPBatchSource extends AbstractFileSource {
   private static final String PATH = "path";
   private static final int DEFAULT_FTP_PORT = 21;
   private static final int DEFAULT_SFTP_PORT = 22;
-
-  public static final Schema SCHEMA = Schema.recordOf("text",
-                                                      Schema.Field.of("offset", Schema.of(Schema.Type.LONG)),
-                                                      Schema.Field.of("body", Schema.of(Schema.Type.STRING)));
   private static final Pattern PATTERN_WITHOUT_SPECIAL_CHARACTERS = Pattern.compile("[^A-Za-z0-9]");
   private final FTPBatchSourceConfig config;
   private Asset asset;
@@ -123,8 +119,7 @@ public class FTPBatchSource extends AbstractFileSource {
   @SuppressWarnings("unused")
   public static class FTPBatchSourceConfig extends PluginConfig implements FileSourceProperties {
     private static final Gson GSON = new Gson();
-    private static final Type MAP_STRING_STRING_TYPE = new TypeToken<Map<String, String>>() {
-    }.getType();
+    private static final Type MAP_STRING_STRING_TYPE = new TypeToken<Map<String, String>>() { }.getType();
 
     @Macro
     @Nullable
@@ -142,6 +137,7 @@ public class FTPBatchSource extends AbstractFileSource {
       + "This is an advanced feature that requires knowledge of the properties supported by the underlying filesystem.")
     private String fileSystemProperties;
 
+    @Macro
     @Nullable
     @Description("Whether to allow an input that does not exist. When false, the source will fail the run if the input "
       + "does not exist. When true, the run will not fail and the source will not generate any output. "
@@ -155,6 +151,37 @@ public class FTPBatchSource extends AbstractFileSource {
       + "See https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html for more information about "
       + "the regular expression syntax.")
     private String fileRegex;
+
+    @Macro
+    @Nullable
+    @Description("Whether to use first row as header. Supported formats are 'text', 'csv', 'tsv', " +
+            "'delimited'. Default value is false.")
+    private Boolean skipHeader;
+
+    @Macro
+    @Nullable
+    @Description("Format of the data to read. Supported formats are 'avro', 'blob', 'csv', 'delimited', 'json', "
+            + "'parquet', 'text', or 'tsv'. If no format is given, it will default to 'text'.")
+    private String format;
+
+    @Macro
+    @Nullable
+    @Description("Output schema for the source. Formats like 'avro' and 'parquet' require a schema in order to "
+            + "read the data.")
+    private String schema;
+
+
+    @VisibleForTesting
+    FTPBatchSourceConfig() {
+      this(null, null, false);
+    }
+
+    @VisibleForTesting
+    FTPBatchSourceConfig(String path, String format, boolean useHeaders) {
+      this.path = path;
+      this.format = format;
+      this.skipHeader = useHeaders;
+    }
 
     @Override
     public void validate(FailureCollector collector) {
@@ -237,7 +264,7 @@ public class FTPBatchSource extends AbstractFileSource {
 
     @Override
     public String getFormatName() {
-      return FileFormat.TEXT.name().toLowerCase();
+      return format == null || format.isEmpty() ? FileFormat.TEXT.name().toLowerCase() : format;
     }
 
     @Nullable
@@ -253,7 +280,7 @@ public class FTPBatchSource extends AbstractFileSource {
 
     @Override
     public boolean shouldAllowEmptyInput() {
-      return false;
+      return ignoreNonExistingFolders != null && ignoreNonExistingFolders;
     }
 
     @Override
@@ -274,13 +301,16 @@ public class FTPBatchSource extends AbstractFileSource {
 
     @Override
     public boolean skipHeader() {
-      return false;
+      return skipHeader == null ? false : skipHeader;
     }
 
     @Nullable
-    @Override
     public Schema getSchema() {
-      return SCHEMA;
+      try {
+        return containsMacro("schema") || Strings.isNullOrEmpty(schema) ? null : Schema.parseJson(schema);
+      } catch (Exception e) {
+        throw new IllegalArgumentException("Invalid schema: " + e.getMessage(), e);
+      }
     }
 
     @VisibleForTesting

--- a/src/test/java/io/cdap/plugin/batch/ETLBatchTestBase.java
+++ b/src/test/java/io/cdap/plugin/batch/ETLBatchTestBase.java
@@ -33,8 +33,6 @@ import io.cdap.cdap.test.ApplicationManager;
 import io.cdap.cdap.test.TestConfiguration;
 import io.cdap.cdap.test.WorkflowManager;
 import io.cdap.plugin.batch.source.ftp.FTPBatchSource;
-import io.cdap.plugin.format.avro.input.AvroInputFormatProvider;
-import io.cdap.plugin.format.avro.output.AvroOutputFormatProvider;
 import io.cdap.plugin.format.blob.input.BlobInputFormatProvider;
 import io.cdap.plugin.format.delimited.input.CSVInputFormatProvider;
 import io.cdap.plugin.format.delimited.input.DelimitedInputFormatProvider;
@@ -44,17 +42,9 @@ import io.cdap.plugin.format.delimited.output.DelimitedOutputFormatProvider;
 import io.cdap.plugin.format.delimited.output.TSVOutputFormatProvider;
 import io.cdap.plugin.format.json.input.JsonInputFormatProvider;
 import io.cdap.plugin.format.json.output.JsonOutputFormatProvider;
-import io.cdap.plugin.format.orc.output.OrcOutputFormatProvider;
-import io.cdap.plugin.format.parquet.input.ParquetInputFormatProvider;
-import io.cdap.plugin.format.parquet.output.ParquetOutputFormatProvider;
 import io.cdap.plugin.format.text.input.TextInputFormatProvider;
-import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
-import org.apache.orc.TypeDescription;
-import org.apache.orc.mapred.OrcStruct;
-import org.apache.orc.mapreduce.OrcOutputFormat;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.xerial.snappy.Snappy;
 
 import java.util.Map;
 import java.util.Set;
@@ -93,10 +83,6 @@ public class ETLBatchTestBase extends HydratorTestBase {
     addPluginArtifact(NamespaceId.DEFAULT.artifact("ftp-plugins", "1.0.0"), parents,
                       FTPBatchSource.class
     );
-    // add format plugins
-    addPluginArtifact(NamespaceId.DEFAULT.artifact("formats-avro", "4.0.0"), DATAPIPELINE_ARTIFACT_ID,
-                      ImmutableSet.of(AvroOutputFormatProvider.PLUGIN_CLASS, AvroInputFormatProvider.PLUGIN_CLASS),
-                      AvroOutputFormatProvider.class, AvroInputFormatProvider.class);
     addPluginArtifact(NamespaceId.DEFAULT.artifact("formats-blob", "4.0.0"), DATAPIPELINE_ARTIFACT_ID,
                       ImmutableSet.of(BlobInputFormatProvider.PLUGIN_CLASS), BlobInputFormatProvider.class);
     addPluginArtifact(NamespaceId.DEFAULT.artifact("formats-delimited", "4.0.0"), DATAPIPELINE_ARTIFACT_ID,
@@ -108,15 +94,6 @@ public class ETLBatchTestBase extends HydratorTestBase {
     addPluginArtifact(NamespaceId.DEFAULT.artifact("formats-json", "4.0.0"), DATAPIPELINE_ARTIFACT_ID,
                       ImmutableSet.of(JsonOutputFormatProvider.PLUGIN_CLASS, JsonInputFormatProvider.PLUGIN_CLASS),
                       JsonOutputFormatProvider.class, JsonInputFormatProvider.class);
-    addPluginArtifact(NamespaceId.DEFAULT.artifact("formats-orc", "4.0.0"), DATAPIPELINE_ARTIFACT_ID,
-                      ImmutableSet.of(OrcOutputFormatProvider.PLUGIN_CLASS),
-                      OrcOutputFormatProvider.class, OrcOutputFormat.class, OrcStruct.class,
-                      TypeDescription.class, TimestampColumnVector.class);
-    addPluginArtifact(NamespaceId.DEFAULT.artifact("formats-parquet", "4.0.0"), DATAPIPELINE_ARTIFACT_ID,
-                      ImmutableSet.of(ParquetOutputFormatProvider.PLUGIN_CLASS,
-                                      ParquetInputFormatProvider.PLUGIN_CLASS),
-                      ParquetOutputFormatProvider.class, ParquetInputFormatProvider.class,
-                      Snappy.class);
     addPluginArtifact(NamespaceId.DEFAULT.artifact("formats-text", "4.0.0"), DATAPIPELINE_ARTIFACT_ID,
                       ImmutableSet.of(TextInputFormatProvider.PLUGIN_CLASS), TextInputFormatProvider.class);
   }

--- a/src/test/java/io/cdap/plugin/batch/ETLFTPTestRun.java
+++ b/src/test/java/io/cdap/plugin/batch/ETLFTPTestRun.java
@@ -17,10 +17,13 @@
 package io.cdap.plugin.batch;
 
 import com.google.common.collect.ImmutableMap;
+import io.cdap.cdap.api.common.Bytes;
 import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.dataset.table.Table;
 import io.cdap.cdap.common.utils.Tasks;
 import io.cdap.cdap.datapipeline.SmartWorkflow;
+import io.cdap.cdap.etl.api.Engine;
 import io.cdap.cdap.etl.api.batch.BatchSource;
 import io.cdap.cdap.etl.mock.batch.MockSink;
 import io.cdap.cdap.etl.proto.v2.ETLBatchConfig;
@@ -36,7 +39,6 @@ import io.cdap.cdap.test.WorkflowManager;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockftpserver.fake.FakeFtpServer;
 import org.mockftpserver.fake.UserAccount;
@@ -45,18 +47,22 @@ import org.mockftpserver.fake.filesystem.FileSystem;
 import org.mockftpserver.fake.filesystem.UnixFakeFileSystem;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 /**
  * FTP Source Test.
  */
 public class ETLFTPTestRun extends ETLBatchTestBase {
-  private static final String USER = "ftp";
-  private static final String PWD = "abcd";
   private static final String TEST_STRING = "Hello World";
   private static final String TEST_STRING_2 = "Goodnight Moon";
   private static File folder;
@@ -68,26 +74,10 @@ public class ETLFTPTestRun extends ETLBatchTestBase {
   private static final String FILE_REGEX = "fileRegex";
 
   @Before
-  public void init() throws Exception {
+  public void setup() throws IOException {
     folder = TMP_FOLDER.newFolder();
-    File file = new File(folder, "sample");
-    file2 = new File(folder, "sample2");
-
-    ftpServer = new FakeFtpServer();
-    ftpServer.setServerControlPort(0);
-
-    FileSystem fileSystem = new UnixFakeFileSystem();
-    fileSystem.add(new FileEntry(file.getAbsolutePath(), TEST_STRING));
-    fileSystem.add(new FileEntry(file2.getAbsolutePath(), TEST_STRING_2));
-    ftpServer.setFileSystem(fileSystem);
-
-    ftpServer.addUserAccount(new UserAccount(USER, PWD, folder.getAbsolutePath()));
-    ftpServer.start();
-
-    Tasks.waitFor(true, () -> ftpServer.isStarted(), 5, TimeUnit.SECONDS);
-    port = ftpServer.getServerControlPort();
   }
-
+  
   @After
   public void stop() {
     if (ftpServer != null) {
@@ -95,38 +85,48 @@ public class ETLFTPTestRun extends ETLBatchTestBase {
     }
   }
 
+  /**
+   * Start a fake FTP Server with a couple fake text files and return the URI for the base folder.
+   */
+  private String startFtpServer() throws Exception {
+    File file = new File(folder, "sample");
+    file2 = new File(folder, "sample2");
+    FileSystem fileSystem = new UnixFakeFileSystem();
+    fileSystem.add(new FileEntry(file.getAbsolutePath(), TEST_STRING));
+    fileSystem.add(new FileEntry(file2.getAbsolutePath(), TEST_STRING_2));
+    return startFtpServer(fileSystem);
+  }
+
+  /**
+   * Start a fake FTP Server with the given filesystem and return the URI for the base folder
+   */
+  private String startFtpServer(FileSystem fileSystem) throws Exception {
+    ftpServer = new FakeFtpServer();
+    ftpServer.setServerControlPort(0);
+    ftpServer.setFileSystem(fileSystem);
+
+    String user = "ftp";
+    String pwd = "abcd";
+    ftpServer.addUserAccount(new UserAccount(user, pwd, folder.getAbsolutePath()));
+    ftpServer.start();
+
+    Tasks.waitFor(true, () -> ftpServer.isStarted(), 5, TimeUnit.SECONDS);
+    port = ftpServer.getServerControlPort();
+    return String.format("ftp://%s:%s@localhost:%d%s", user, pwd, port, folder.getAbsolutePath());
+  }
+
   @Test
-  public void testFTPBatchSource() throws Exception {
+  public void testText() throws Exception {
+    String path = startFtpServer();
     ETLStage source = new ETLStage("source", new ETLPlugin(
       "FTP",
       BatchSource.PLUGIN_TYPE,
       ImmutableMap.<String, String>builder()
-        .put(PATH, String.format("ftp://%s:%s@localhost:%d%s",
-                                 USER, PWD, port, folder.getAbsolutePath()))
+        .put(PATH, path)
         .put(IGNORE_NON_EXISTING_FOLDERS, "false")
         .put("referenceName", "ftp")
-        .build(),
-      null));
-
-    String outputDatasetName = "testing-ftp-source";
-    ETLStage sink = new ETLStage("sink", MockSink.getPlugin(outputDatasetName));
-
-    ETLBatchConfig etlConfig = ETLBatchConfig.builder()
-      .addStage(source)
-      .addStage(sink)
-      .addConnection(source.getName(), sink.getName())
-      .build();
-
-    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(DATAPIPELINE_ARTIFACT, etlConfig);
-    ApplicationId appId = NamespaceId.DEFAULT.app("FTPBatchSource");
-
-    ApplicationManager appManager = deployApplication(appId, appRequest);
-
-    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
-    workflowManager.startAndWaitForRun(ProgramRunStatus.COMPLETED, 30, TimeUnit.SECONDS);
-
-    DataSetManager<Table> outputManager = getDataset(outputDatasetName);
-    List<StructuredRecord> output = MockSink.readOutput(outputManager);
+        .build()));
+    List<StructuredRecord> output = runPipeline(source);
 
     Assert.assertEquals("Expected records", 2, output.size());
     Set<String> outputValue = new HashSet<>();
@@ -138,61 +138,135 @@ public class ETLFTPTestRun extends ETLBatchTestBase {
   }
 
   @Test
-  public void testFTPBatchSourceWithRegex() throws Exception {
+  public void testBlob() throws Exception {
+    FileSystem fileSystem = new UnixFakeFileSystem();
+    fileSystem.add(new FileEntry(folder.getAbsolutePath() + "/test.txt", "a\nb\nc"));
+    String path = startFtpServer(fileSystem);
+
     ETLStage source = new ETLStage("source", new ETLPlugin(
       "FTP",
       BatchSource.PLUGIN_TYPE,
       ImmutableMap.<String, String>builder()
-        .put(PATH, String.format("ftp://%s:%s@localhost:%d%s",
-                                 USER, PWD, port, folder.getAbsolutePath()))
+        .put(PATH, path + "/test.txt")
+        .put("referenceName", "ftp")
+        .put("format", "blob")
+        .build()));
+    List<StructuredRecord> output = runPipeline(source);
+    Assert.assertEquals(1, output.size());
+    ByteBuffer bodyBytes = output.get(0).get("body");
+    Assert.assertArrayEquals("a\nb\nc".getBytes(StandardCharsets.UTF_8), Bytes.toBytes(bodyBytes));
+  }
+
+  @Test
+  public void testJson() throws Exception {
+    FileSystem fileSystem = new UnixFakeFileSystem();
+    fileSystem.add(new FileEntry(folder.getAbsolutePath() + "/test.json", "{ \"a\":\"x\" }"));
+    String path = startFtpServer(fileSystem);
+
+    Schema schema = Schema.recordOf("r",
+                                    Schema.Field.of("a", Schema.of(Schema.Type.STRING)),
+                                    Schema.Field.of("b", Schema.nullableOf(Schema.of(Schema.Type.STRING))));
+    ETLStage source = new ETLStage("source", new ETLPlugin(
+      "FTP",
+      BatchSource.PLUGIN_TYPE,
+      ImmutableMap.<String, String>builder()
+        .put(PATH, path + "/test.json")
+        .put("referenceName", "ftp")
+        .put("format", "json")
+        .put("schema", schema.toString())
+        .build()));
+    List<StructuredRecord> output = runPipeline(source);
+    List<StructuredRecord> expected = Collections.singletonList(
+      StructuredRecord.builder(schema).set("a", "x").build());
+    Assert.assertEquals(expected, output);
+  }
+
+  @Test
+  public void testCSV() throws Exception {
+    testDelimited("csv", ",", true);
+    testDelimited("csv", ",", false);
+  }
+
+  @Test
+  public void testTSV() throws Exception {
+    testDelimited("tsv", "\t", true);
+    testDelimited("tsv", "\t", false);
+  }
+
+  @Test
+  public void testDelimited() throws Exception {
+    testDelimited("delimited", "|", true);
+    testDelimited("delimited", "|", false);
+  }
+
+  private void testDelimited(String format, String delimiter, boolean useHeader) throws Exception {
+    Schema schema = Schema.recordOf("user",
+                                    Schema.Field.of("id", Schema.of(Schema.Type.INT)),
+                                    Schema.Field.of("name", Schema.of(Schema.Type.STRING)),
+                                    Schema.Field.of("email", Schema.nullableOf(Schema.of(Schema.Type.STRING))));
+    Set<StructuredRecord> expected = new HashSet<>(2);
+    expected.add(StructuredRecord.builder(schema)
+                   .set("id", 0).set("name", "Alice").build());
+    expected.add(StructuredRecord.builder(schema)
+                   .set("id", 1).set("name", "Bob").set("email", "bob@example.com").build());
+    FileSystem fileSystem = new UnixFakeFileSystem();
+
+    StringBuilder fileContent = new StringBuilder();
+    if (useHeader) {
+      fileContent.append("id").append(delimiter).append("name").append(delimiter).append("email").append("\n");
+    }
+    fileContent.append("0").append(delimiter).append("Alice").append(delimiter).append("\n");
+    fileContent.append("1").append(delimiter).append("Bob").append(delimiter).append("bob@example.com").append("\n");
+    fileSystem.add(new FileEntry(folder.getAbsolutePath() + "/test.csv", fileContent.toString()));
+    String path = startFtpServer(fileSystem);
+
+    ETLStage source = new ETLStage("source", new ETLPlugin(
+      "FTP",
+      BatchSource.PLUGIN_TYPE,
+      ImmutableMap.<String, String>builder()
+        .put(PATH, path + "/test.csv")
+        .put("skipHeader", Boolean.valueOf(useHeader).toString())
+        .put("referenceName", "ftp")
+        .put("format", format)
+        .put("delimiter", delimiter)
+        .put("schema", schema.toString())
+        .build()));
+    Set<StructuredRecord> output = new HashSet<>(runPipeline(source));
+    Assert.assertEquals(expected, output);
+  }
+
+  @Test
+  public void testFTPBatchSourceWithRegex() throws Exception {
+    String path = startFtpServer();
+    ETLStage source = new ETLStage("source", new ETLPlugin(
+      "FTP",
+      BatchSource.PLUGIN_TYPE,
+      ImmutableMap.<String, String>builder()
+        .put(PATH, path)
         .put(IGNORE_NON_EXISTING_FOLDERS, "false")
         .put(FILE_REGEX, file2.getAbsolutePath())
         .put("referenceName", "ftp")
-        .build(),
-      null));
-
-    String outputDatasetName = "testing-ftp-source-with-regex";
-    ETLStage sink = new ETLStage("sink", MockSink.getPlugin(outputDatasetName));
-
-    ETLBatchConfig etlConfig = ETLBatchConfig.builder()
-      .addStage(source)
-      .addStage(sink)
-      .addConnection(source.getName(), sink.getName())
-      .build();
-
-    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(DATAPIPELINE_ARTIFACT, etlConfig);
-    ApplicationId appId = NamespaceId.DEFAULT.app("FTPBatchSource");
-
-    ApplicationManager appManager = deployApplication(appId, appRequest);
-
-    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
-    workflowManager.startAndWaitForRun(ProgramRunStatus.COMPLETED, 30, TimeUnit.SECONDS);
-
-    DataSetManager<Table> outputManager = getDataset(outputDatasetName);
-    List<StructuredRecord> output = MockSink.readOutput(outputManager);
+        .build()));
+    List<StructuredRecord> output = runPipeline(source);
 
     Assert.assertEquals("Expected records", 1, output.size());
     Assert.assertEquals("Single file", TEST_STRING_2, output.get(0).get("body"));
   }
 
-  private void testHelper(Map<String, String> properties, Map<String, String> runTimeProperties) throws Exception {
+  @Test
+  public void testFTPBatchSourceWithMacro() throws Exception {
     ETLStage source = new ETLStage("source", new ETLPlugin(
-      "FTP", BatchSource.PLUGIN_TYPE, properties, null));
-
-    String outputDatasetName = "testing-ftp-source-with-macro";
-    ETLStage sink = new ETLStage("sink", MockSink.getPlugin(outputDatasetName));
-
-    ETLBatchConfig etlConfig = ETLBatchConfig.builder()
-      .addStage(source)
-      .addStage(sink)
-      .addConnection(source.getName(), sink.getName())
-      .build();
-
-    ApplicationManager appManager = deployETL(etlConfig, "FTPWithMacro");
-    runETLOnce(appManager, runTimeProperties);
-
-    DataSetManager<Table> outputManager = getDataset(outputDatasetName);
-    List<StructuredRecord> output = MockSink.readOutput(outputManager);
+      "FTP",
+      BatchSource.PLUGIN_TYPE,
+      ImmutableMap.<String, String>builder()
+        .put(PATH, "${path}")
+        .put("referenceName", "${referenceName}")
+        .build()));
+    String path = startFtpServer();
+    Map<String, String> args = new HashMap<>();
+    args.put("path", path);
+    args.put("referenceName", "ftp_with_macro");
+    List<StructuredRecord> output = runPipeline(source, args);
 
     Assert.assertEquals("Expected records", 2, output.size());
     Set<String> outputValue = new HashSet<>();
@@ -200,15 +274,6 @@ public class ETLFTPTestRun extends ETLBatchTestBase {
       outputValue.add(record.get("body"));
     }
     Assert.assertTrue(outputValue.contains("Hello World"));
-  }
-
-  @Test
-  @Ignore
-  public void testFTPBatchSourceWithMacro() throws Exception {
-    testHelper(ImmutableMap.of("path", "${path}", "referenceName", "${referenceName}"),
-               ImmutableMap.of("path", String.format("ftp://%s:%s@localhost:%d%s",
-                                                     USER, PWD, port, folder.getAbsolutePath()),
-                               "referenceName", "ftp_with_macro"));
   }
 
   @Test
@@ -221,8 +286,7 @@ public class ETLFTPTestRun extends ETLBatchTestBase {
                                  port, folder.getAbsolutePath()))
         .put(IGNORE_NON_EXISTING_FOLDERS, "false")
         .put("referenceName", "ftp")
-        .build(),
-      null));
+        .build()));
 
     String outputDatasetName = "testing-ftp-source";
     ETLStage sink = new ETLStage("sink", MockSink.getPlugin(outputDatasetName));
@@ -231,6 +295,7 @@ public class ETLFTPTestRun extends ETLBatchTestBase {
       .addStage(source)
       .addStage(sink)
       .addConnection(source.getName(), sink.getName())
+      .setEngine(Engine.SPARK)
       .build();
 
     AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(DATAPIPELINE_ARTIFACT, etlConfig);
@@ -243,5 +308,32 @@ public class ETLFTPTestRun extends ETLBatchTestBase {
     } catch (Exception e) {
       //
     }
+  }
+
+  private List<StructuredRecord> runPipeline(ETLStage sourceConfig) throws Exception {
+    return runPipeline(sourceConfig, Collections.emptyMap());
+  }
+
+  private List<StructuredRecord> runPipeline(ETLStage sourceConfig, Map<String, String> runtimeArgs) throws Exception {
+    String outputDatasetName = UUID.randomUUID().toString();
+    ETLStage sink = new ETLStage("sink", MockSink.getPlugin(outputDatasetName));
+
+    ETLBatchConfig config = ETLBatchConfig.builder()
+      .addStage(sourceConfig)
+      .addStage(sink)
+      .addConnection(sourceConfig.getName(), sink.getName())
+      .setEngine(Engine.SPARK)
+      .build();
+
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(DATAPIPELINE_ARTIFACT, config);
+    ApplicationId appId = NamespaceId.DEFAULT.app(UUID.randomUUID().toString());
+
+    ApplicationManager appManager = deployApplication(appId, appRequest);
+
+    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
+    workflowManager.startAndWaitForRun(runtimeArgs, ProgramRunStatus.COMPLETED, 30, TimeUnit.SECONDS);
+
+    DataSetManager<Table> outputManager = getDataset(outputDatasetName);
+    return MockSink.readOutput(outputManager);
   }
 }

--- a/widgets/FTP-batchsource.json
+++ b/widgets/FTP-batchsource.json
@@ -18,6 +18,84 @@
           "widget-type": "textbox",
           "label": "Path",
           "name": "path"
+        },
+        {
+          "widget-type": "select",
+          "label": "Format",
+          "name": "format",
+          "widget-attributes": {
+            "default": "text",
+            "values": [
+              {
+                "label": "blob",
+                "value": "blob"
+              },
+              {
+                "label": "csv",
+                "value": "csv"
+              },
+              {
+                "label": "delimited",
+                "value": "delimited"
+              },
+              {
+                "label": "json",
+                "value": "json"
+              },
+              {
+                "label": "text",
+                "value": "text"
+              },
+              {
+                "label": "tsv",
+                "value": "tsv"
+              }
+            ]
+          }
+        },
+        {
+          "widget-type": "get-schema",
+          "widget-category": "plugin"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Delimiter",
+          "name": "delimiter",
+          "widget-attributes": {
+            "placeholder": "Delimiter if the format is 'delimited'"
+          }
+        },
+        {
+          "widget-type": "toggle",
+          "name": "enableQuotedValues",
+          "label": "Enable Quoted Values",
+          "widget-attributes": {
+            "default": "false",
+            "on": {
+              "value": "true",
+              "label": "True"
+            },
+            "off": {
+              "value": "false",
+              "label": "False"
+            }
+          }
+        },
+        {
+          "widget-type": "toggle",
+          "name": "skipHeader",
+          "label": "Use First Row as Header",
+          "widget-attributes": {
+            "default": "false",
+            "on": {
+              "value": "true",
+              "label": "True"
+            },
+            "off": {
+              "value": "false",
+              "label": "False"
+            }
+          }
         }
       ]
     },
@@ -58,21 +136,59 @@
   ],
   "outputs": [
     {
-      "widget-type": "non-editable-schema-editor",
-      "schema": {
-        "name": "etlSchemaBody",
-        "type": "record",
-        "fields": [
-          {
-            "name": "offset",
-            "type": "long"
-          },
-          {
-            "name": "body",
-            "type": "string"
-          }
-        ]
+      "name": "schema",
+      "widget-type": "schema",
+      "widget-attributes": {
+        "default-schema": {
+          "name": "fileRecord",
+          "type": "record",
+          "fields": [
+            {
+              "name": "offset",
+              "type": "long"
+            },
+            {
+              "name": "body",
+              "type": "string"
+            }
+          ]
+        }
       }
+    }
+  ],
+  "filters": [
+    {
+      "name": "delimiter",
+      "condition": {
+        "expression": "format == 'delimited'"
+      },
+      "show": [
+        {
+          "name": "delimiter"
+        }
+      ]
+    },
+    {
+      "name": "enableQuotedValues",
+      "condition": {
+        "expression": "format == 'delimited' || format == 'csv' || format == 'tsv'"
+      },
+      "show": [
+        {
+          "name": "enableQuotedValues"
+        }
+      ]
+    },
+    {
+      "name": "skipHeader",
+      "condition": {
+        "expression": "format == 'delimited' || format == 'csv' || format == 'tsv'"
+      },
+      "show": [
+        {
+          "name": "skipHeader"
+        }
+      ]
     }
   ],
   "jump-config": {


### PR DESCRIPTION
Added support for formats, except restricting the UI and docs to leave out avro, parquet, and orc due to the lack of file seek in FTP. Also added/implemented several standard config properties supported by the other file based sources, like delimiter, whether to allow empty input, schema, etc.