### PR TITLE
PLUGIN-1493 add missing config properties

### DIFF
--- a/src/main/java/io/cdap/plugin/batch/source/ftp/FTPBatchSource.java
+++ b/src/main/java/io/cdap/plugin/batch/source/ftp/FTPBatchSource.java
@@ -170,6 +170,18 @@ public class FTPBatchSource extends AbstractFileSource<FTPBatchSource.FTPBatchSo
             + "read the data.")
     private String schema;
 
+    @Macro
+    @Nullable
+    @Description("The delimiter to use if the format is 'delimited'. The delimiter will be ignored if the format "
+      + "is anything other than 'delimited'.")
+    private String delimiter;
+
+    @Macro
+    @Nullable
+    @Description("Whether to treat content between quotes as a value. This value will only be used if the format " +
+      "is 'csv', 'tsv' or 'delimited'. The default value is false.")
+    protected Boolean enableQuotedValues;
+
 
     @VisibleForTesting
     FTPBatchSourceConfig() {


### PR DESCRIPTION
Add delimiter and quoted flag as explicit properties in the config class so that they are properly displayed by the UI