### PR TITLE
PLUGIN-1520 fix get schema for password with special chars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>io.cdap.plugin</groupId>
   <artifactId>ftp-plugins</artifactId>
-  <version>3.1.0</version>
+  <version>3.1.1</version>
 
   <licenses>
     <license>

--- a/src/main/java/io/cdap/plugin/batch/source/ftp/FTPBatchSource.java
+++ b/src/main/java/io/cdap/plugin/batch/source/ftp/FTPBatchSource.java
@@ -48,6 +48,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
+import javax.ws.rs.core.UriBuilder;
 
 /**
  * {@link BatchSource} that reads from an FTP or SFTP server.
@@ -76,11 +77,9 @@ public class FTPBatchSource extends AbstractFileSource<FTPBatchSource.FTPBatchSo
   }
 
   @Override
-  protected Map<String, String> getFileSystemProperties(BatchSourceContext context) {
-    Map<String, String> properties = new HashMap<>();
-    if (context != null) {
-      properties.putAll(config.getFileSystemProperties(context.getFailureCollector()));
-    }
+  protected Map<String, String> getFileSystemProperties(@Nullable BatchSourceContext context) {
+    FailureCollector failureCollector = context == null ? null : context.getFailureCollector();
+    Map<String, String> properties = new HashMap<>(config.getFileSystemProperties(failureCollector));
 
     if (!properties.containsKey(FS_SFTP_IMPL)) {
       properties.put(FS_SFTP_IMPL, SFTP_FS_CLASS);
@@ -183,11 +182,8 @@ public class FTPBatchSource extends AbstractFileSource<FTPBatchSource.FTPBatchSo
         Map<String, String> fsp = getFileSystemProperties(collector);
         try {
           Path urlInfo;
-          String extractedPassword = extractPasswordFromUrl();
-          String encodedPassword = URLEncoder.encode(extractedPassword);
-          String validatePath = path.replace(extractedPassword, encodedPassword);
           try {
-            urlInfo = new Path(validatePath);
+            urlInfo = new Path(getPath());
           } catch (Exception e) {
             throw new IllegalArgumentException(String.format("Unable to parse url: %s %s", e.getMessage(), e));
           }
@@ -235,8 +231,6 @@ public class FTPBatchSource extends AbstractFileSource<FTPBatchSource.FTPBatchSo
         } catch (Exception e) {
           throw new IllegalArgumentException(String.format("Unable to parse url: %s %s", e.getMessage(), e));
         }
-        String host = urlInfo.toUri().getAuthority().substring(urlInfo.toUri().getAuthority().lastIndexOf("@") + 1);
-        String user = urlInfo.toUri().getAuthority().split(":")[0];
         String protocol = urlInfo.toUri().getScheme();
         int port = urlInfo.toUri().getPort();
         if (port == -1 && protocol.equals(FTP_PROTOCOL)) {
@@ -245,8 +239,7 @@ public class FTPBatchSource extends AbstractFileSource<FTPBatchSource.FTPBatchSo
         if (port == -1 && protocol.equals(SFTP_PROTOCOL)) {
           port = DEFAULT_SFTP_PORT;
         }
-        String cleanHost = host.replace(":" + port, "");
-        return urlInfo.toUri().getScheme() + "://" + cleanHost + urlInfo.toUri().getPath();
+        return UriBuilder.fromUri(urlInfo.toUri()).port(port).userInfo(null).toString();
       }
       return path;
     }
@@ -330,7 +323,7 @@ public class FTPBatchSource extends AbstractFileSource<FTPBatchSource.FTPBatchSo
       return specialCharacters.find();
     }
 
-    Map<String, String> getFileSystemProperties(FailureCollector collector) {
+    Map<String, String> getFileSystemProperties(@Nullable FailureCollector collector) {
       HashMap<String, String> fileSystemPropertiesMap = new HashMap<>();
       if (!Strings.isNullOrEmpty(fileSystemProperties)) {
         fileSystemPropertiesMap.putAll(GSON.fromJson(fileSystemProperties, MAP_STRING_STRING_TYPE));

--- a/src/test/java/io/cdap/plugin/batch/source/ftp/FTPBatchSourceTest.java
+++ b/src/test/java/io/cdap/plugin/batch/source/ftp/FTPBatchSourceTest.java
@@ -18,7 +18,6 @@ package io.cdap.plugin.batch.source.ftp;
 
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.etl.api.FailureCollector;
-import io.cdap.cdap.etl.api.PipelineConfigurer;
 import io.cdap.cdap.etl.api.validation.ValidationException;
 import io.cdap.cdap.etl.mock.common.MockPipelineConfigurer;
 import io.cdap.cdap.etl.mock.validation.MockFailureCollector;
@@ -35,7 +34,6 @@ import org.mockftpserver.fake.filesystem.FileEntry;
 import org.mockftpserver.fake.filesystem.FileSystem;
 import org.mockftpserver.fake.filesystem.UnixFakeFileSystem;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -63,6 +61,7 @@ public class FTPBatchSourceTest {
   public static void ftpSetup() {
     ftpServer = new FakeFtpServer();
     ftpServer.addUserAccount(new UserAccount("user", "password", "/tmp"));
+    ftpServer.addUserAccount(new UserAccount("user2", PASSWORD_WITH_SPECIAL_CHARACTERS, "/tmp"));
     ftpServer.setServerControlPort(0);
 
     FileSystem fileSystem = new UnixFakeFileSystem();
@@ -83,7 +82,8 @@ public class FTPBatchSourceTest {
 
   @Test
   public void testSchemaDetection() {
-    String path = String.format("ftp://user:password@%s:%d/tmp/file1.txt", HOST, ftpServerPort);
+    String path = String.format("ftp://user2:%s@%s:%d/tmp/file1.txt",
+                                PASSWORD_WITH_SPECIAL_CHARACTERS, HOST, ftpServerPort);
     FTPBatchSource.FTPBatchSourceConfig config = new FTPBatchSource.FTPBatchSourceConfig(path, "csv", false);
     FTPBatchSource ftpBatchSource = new FTPBatchSource(config);
     Map<String, Object> plugins = new HashMap<>();
@@ -153,6 +153,7 @@ public class FTPBatchSourceTest {
     fileSystemProperties.put(String.format("fs.sftp.password.%s.%s", HOST, USER), PASSWORD_WITH_SPECIAL_CHARACTERS);
     fileSystemProperties.put("fs.sftp.host.port", String.valueOf(SFTP_DEFAULT_PORT));
     Assert.assertEquals(fileSystemProperties, config.getFileSystemProperties(collector));
+    Assert.assertEquals(String.format("%s://%s:%d%s", SFTP_PREFIX, HOST, SFTP_DEFAULT_PORT, PATH), config.getPath());
   }
 
   @Test


### PR DESCRIPTION
Fixed the source to properly set the password and username for schema fetching when there is a special character in the password.

Also fixed a validation bug where a password with a special char would incorrectly use the encoded password instead for auth.