### PR TITLE
Bump cdap and spark

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,24 +34,41 @@
 
   <properties>
     <!-- properties for script build step that creates the config files for the artifacts -->
-    <data.pipeline.parent>system:cdap-data-pipeline[6.9.2-SNAPSHOT,7.0.0-SNAPSHOT)</data.pipeline.parent>
-    <data.stream.parent>system:cdap-data-streams[6.9.2-SNAPSHOT,7.0.0-SNAPSHOT)</data.stream.parent>
-    <cdap.version>6.8.0</cdap.version>
-    <hydrator.version>2.10.0</hydrator.version>
-    <hadoop.version>2.3.0</hadoop.version>
+    <data.pipeline.parent>system:cdap-data-pipeline[6.11.0-SNAPSHOT,7.0.0-SNAPSHOT)</data.pipeline.parent>
+    <data.stream.parent>system:cdap-data-streams[6.11.0-SNAPSHOT,7.0.0-SNAPSHOT)</data.stream.parent>
+    <cdap.version>6.11.0-SNAPSHOT</cdap.version>
+    <hydrator.version>2.13.0-SNAPSHOT</hydrator.version>
+    <hadoop.version>3.3.6</hadoop.version>
     <mockftp.version>2.6</mockftp.version>
     <junit.version>4.11</junit.version>
     <mockito.version>2.24.0</mockito.version>
     <guava.version>13.0.1</guava.version>
+    <jackson.version>2.13.0</jackson.version>
     <surefire.redirectTestOutputToFile>true</surefire.redirectTestOutputToFile>
   </properties>
 
-  <pluginRepositories>
-    <pluginRepository>
+  <repositories>
+    <repository>
       <id>sonatype</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-    </pluginRepository>
-  </pluginRepositories>
+      <url>https://oss.sonatype.org/content/groups/public</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+    <repository>
+      <id>sonatype-snapshots</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
 
   <dependencies>
     <dependency>
@@ -96,7 +113,7 @@
     </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
-      <artifactId>cdap-data-pipeline2_2.11</artifactId>
+      <artifactId>cdap-data-pipeline3_2.12</artifactId>
       <version>${cdap.version}</version>
       <scope>test</scope>
     </dependency>
@@ -117,6 +134,12 @@
           <artifactId>asm</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
@@ -267,7 +290,7 @@
     </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
-      <artifactId>cdap-data-pipeline2_2.11</artifactId>
+      <artifactId>cdap-data-pipeline3_2.12</artifactId>
       <version>${cdap.version}</version>
       <scope>test</scope>
     </dependency>
@@ -296,18 +319,6 @@
       <groupId>io.cdap.plugin</groupId>
       <artifactId>format-text</artifactId>
       <version>${hydrator.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.cdap.cdap</groupId>
-      <artifactId>cdap-explore</artifactId>
-      <version>${cdap.version}</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>io.cdap.cdap</groupId>
-          <artifactId>cdap-unit-test</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
## Bump cdap, hadoop version

### Changes Made 

- Bump `cdap.version` / `hadoop.version` / `hydrator.version`
- Bump `cdap-data-pipeline` lower bound
- Bump `cdap-data-stream` lower bound
- Add snapshot repository 
- Remove test dependency `cdap-explore`
  -  There is no compatible version, last version released was for 6.9.0
  -  Does not look like it's being used anywhere
- Add test dependency `jackson-databind`
  - Another version was being loaded not compatible with spark3, added the bumped up version in plugin pom


