### PR TITLE
Bump version to 4.1.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>io.cdap.plugin</groupId>
   <artifactId>ftp-plugins</artifactId>
-  <version>4.0.0-SNAPSHOT</version>
+  <version>4.1.0-SNAPSHOT</version>
 
   <licenses>
     <license>


### PR DESCRIPTION
4.0.0 is released on hub with cdap version [6.9.2,7.0.0-SNAPSHOT)
Error management is not backward compatible hence we need to bump to 4.1.0-SNAPSHOT