### PR TITLE
Sync GitHub action with develop branch

### DIFF
--- a/.github/workflows/build-report.yml
+++ b/.github/workflows/build-report.yml
@@ -21,6 +21,12 @@ on:
     types:
     - completed
 
+permissions:
+  actions: read    # Allows reading workflow run information
+  statuses: write  # Required if the action updates commit statuses
+  checks: write    # Required if it updates GitHub Checks API
+
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,11 +37,11 @@ jobs:
          && (github.event.action != 'labeled' || github.event.label.name == 'build')
          )
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
       - name: Cache
-        uses: actions/cache@v2.1.3
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ github.workflow }}-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
## This branch has broken GitHub Actions


- ref (https://github.com/data-integrations/ftp-plugins/pull/69)
![image](https://github.com/user-attachments/assets/3f08a304-e356-4fc2-8832-8aaa6d7b5fb7)


### Command used to create this patch

-  This will sync all the changes done in develop branch for the dir 

```bash
git diff HEAD develop -- .github/*
```
